### PR TITLE
Little fix for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you need icons on a ```TextView```, use the ```{ }``` syntax. You can put any
     ... />
 ```
 
-> You can either use ```IconTextView``` / ```ButtonTextView``` or use any ```TextView``` and then programmatically call ```Iconify.addIcons(myTextView);```.
+> You can either use ```IconTextView``` / ```IconButton``` or use any ```TextView``` and then programmatically call ```Iconify.addIcons(myTextView);```.
 
 ### Get started #2
 
@@ -69,7 +69,7 @@ repositories {
 ...
 dependencies {
     ...
-    compile 'com.malinskiy:materialicons:1.0.2'
+    implementation 'com.malinskiy:materialicons:1.0.2'
     ...
 }
 ```


### PR DESCRIPTION
Wrong name: it's "IconButton" not "ButtonTextView"
Deprecated: it's "implementation" not "compile" anymore for Gradle